### PR TITLE
Support Fatsoma payment process

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# example env file for local docker run
+
+# Stripe Webhook:
+WEBHOOK_URL=http://host.docker.internal:8082/stripe/webhook
+WEBHOOK_SIGNING_SECRET=your_secret
+
+# Stripe Connect Webhook:
+CONNECT_WEBHOOK_URL=http://host.docker.internal:8082/stripe/connect-webhook
+CONNECT_WEBHOOK_SIGNING_SECRET=your_connect_secret

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ __pycache__
 *.py[cod]
 /dist
 /*.egg-info
+
+.env.*
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3
 
-RUN pip install localstripe
+COPY . /app
+
+RUN cd /app && \
+  rm dist/localstripe-*.tar.gz && \
+  python setup.py sdist && \
+  pip install dist/localstripe-*.tar.gz && \
+  rm -rf /app
 
 CMD ["localstripe"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 FROM python:3
 
+ENV VAULT_VERSION=1.3.1
+
+RUN cd /tmp && \
+  wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+  unzip vault_${VAULT_VERSION}_linux_amd64.zip && \
+  mv vault /usr/local/bin/vault && \
+  rm vault_${VAULT_VERSION}_linux_amd64.zip
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 COPY . /app
 
 RUN cd /app && \
@@ -8,4 +19,7 @@ RUN cd /app && \
   pip install dist/localstripe-*.tar.gz && \
   rm -rf /app
 
-CMD ["localstripe"]
+ENV PORT=8420
+EXPOSE 8420
+
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3
+
+RUN pip install localstripe
+
+CMD ["localstripe"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+.PHONY: all
+all: help
+
+PROJECTNAME = localstripe
+ENV ?= preview
+ifeq ($(ENV),sandbox)
+REGION = us-east-1
+else
+REGION = us-west-1
+endif
+LOCAL_TAG = $(ENV)-$(REGION)-localstripe:latest
+ECR_TAG = 819738237059.dkr.ecr.$(REGION).amazonaws.com/$(ENV)-$(REGION)-localstripe:latest
+
+SYSTEM = $(shell uname -s)
+HOST_POST ?= 8420
+HOST_NAME=host.docker.internal
+RUN_ENV ?= development
+
+## docker-login: Login to ECR repository
+.PHONY: docker-login
+docker-login:
+	@echo "  > Logging in to ECR repository for environment $(ENV)"
+	@$(shell aws ecr get-login --region $(REGION) --no-include-email)
+
+## docker-build: Build docker image ENV=preview (default)
+.PHONY: docker-build
+docker-build:
+	@echo "  > Building Docker image $(LOCAL_TAG)"
+	@docker build -t $(LOCAL_TAG) .
+	@echo "  > Build Completed"
+
+## docker-push: Push docker image ENV=preview (default)
+.PHONY: docker-push
+docker-push:
+	@echo "  > Tagging image: $(ECR_TAG)"
+	@docker tag $(LOCAL_TAG) $(ECR_TAG)
+	@echo "  > Pushing docker image: $(ECR_TAG)"
+	@docker push $(ECR_TAG)
+	@echo "  > Push Completed"
+
+## docker-run: Run docker image locally RUN_ENV=development (default)
+.PHONY: docker-run
+ifeq ($(SYSTEM),Darwin)
+docker-run:
+	@echo "  > Running docker image: $(LOCAL_TAG)"
+	@docker run --rm -p $(HOST_PORT):8420 --env-file .env.$(RUN_ENV) $(LOCAL_TAG)
+else
+HOST_IP ?= $(shell docker network inspect bridge -f "{{json (index .IPAM.Config 0).Gateway}}")
+docker-run:
+	@echo "  > Running docker image: $(LOCAL_TAG) with host $(HOST_NAME):$(HOST_IP)"
+	@docker run --rm -p $(HOST_PORT):80 --add-host "$(HOST_NAME):$(HOST_IP)" --env-file .env.$(RUN_ENV) $(LOCAL_TAG)
+endif
+
+## docker-image: Combine docker build and push
+.PHONY: docker-image
+docker-image: docker-build docker-push
+
+.PHONY: help
+help: Makefile
+	@echo
+	@echo "Choose a command to run in: '$(PROJECTNAME)':"
+	@echo
+	@sed -n 's/^##//p' $< | column -t -s ':' | sed -e 's/^/ /'
+	@echo

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ else
 REGION = us-west-1
 endif
 LOCAL_TAG = $(ENV)-$(REGION)-localstripe:latest
-ECR_TAG = 819738237059.dkr.ecr.$(REGION).amazonaws.com/$(ENV)-$(REGION)-localstripe:latest
+ECR_URL = 819738237059.dkr.ecr.$(REGION).amazonaws.com
+ECR_TAG = $(ECR_URL)/$(ENV)-$(REGION)-localstripe:latest
 
 SYSTEM = $(shell uname -s)
 HOST_POST ?= 8420
@@ -20,7 +21,7 @@ RUN_ENV ?= development
 .PHONY: docker-login
 docker-login:
 	@echo "  > Logging in to ECR repository for environment $(ENV)"
-	@$(shell aws ecr get-login --region $(REGION) --no-include-email)
+	@aws ecr get-login-password --region $(REGION) | docker login --username AWS --password-stdin $(ECR_URL)
 
 ## docker-build: Build docker image ENV=preview (default)
 .PHONY: docker-build

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ECR_URL = 819738237059.dkr.ecr.$(REGION).amazonaws.com
 ECR_TAG = $(ECR_URL)/$(ENV)-$(REGION)-localstripe:latest
 
 SYSTEM = $(shell uname -s)
-HOST_POST ?= 8420
+HOST_PORT ?= 8420
 HOST_NAME=host.docker.internal
 RUN_ENV ?= development
 
@@ -49,7 +49,7 @@ else
 HOST_IP ?= $(shell docker network inspect bridge -f "{{json (index .IPAM.Config 0).Gateway}}")
 docker-run:
 	@echo "  > Running docker image: $(LOCAL_TAG) with host $(HOST_NAME):$(HOST_IP)"
-	@docker run --rm -p $(HOST_PORT):80 --add-host "$(HOST_NAME):$(HOST_IP)" --env-file .env.$(RUN_ENV) $(LOCAL_TAG)
+	@docker run --rm -p $(HOST_PORT):8420 --add-host "$(HOST_NAME):$(HOST_IP)" --env-file .env.$(RUN_ENV) $(LOCAL_TAG)
 endif
 
 ## docker-image: Combine docker build and push

--- a/README.rst
+++ b/README.rst
@@ -61,11 +61,7 @@ Docker image can be rebuilt using:
 
 .. code::
 
- docker build --no-cache -t adrienverge/localstripe -<<EOF
- FROM python:3
- RUN pip install localstripe
- CMD ["localstripe"]
- EOF
+ docker build --no-cache -t adrienverge/localstripe .
 
 Examples
 --------

--- a/README.rst
+++ b/README.rst
@@ -55,18 +55,7 @@ Or launch a container using `the Docker image
 
 .. code:: shell
 
- docker run --rm -p 8420:8420 \
-   -e ENV=preview \
-   -e VAULT_ADDR \
-   fatsoma/localstripe:latest
-
- docker run --rm -p 8420:8420 \
-   --add-host host.docker.internal:$(docker network inspect bridge -f "{{json (index .IPAM.Config 0).Gateway}}" | tr -d \") \
-   -e WEBHOOK_URL=http://host.docker.internal:8082/stripe/webhook \
-   -e WEBHOOK_SIGNING_SECRET \
-   -e CONNECT_WEBHOOK_URL=http://host.docker.internal:8082/stripe/connect-webhook \
-   -e CONNECT_WEBHOOK_SIGNING_SECRET \
-   fatsoma/localstripe:latest
+ make docker-run ENV=development
 
 Docker image can be rebuilt using:
 

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,18 @@ Or launch a container using `the Docker image
 
 .. code:: shell
 
- docker run -p 8420:8420 fatsoma/localstripe:latest
+ docker run --rm -p 8420:8420 \
+   -e ENV=preview \
+   -e VAULT_ADDR \
+   fatsoma/localstripe:latest
+
+ docker run --rm -p 8420:8420 \
+   --add-host host.docker.internal:$(docker network inspect bridge -f "{{json (index .IPAM.Config 0).Gateway}}" | tr -d \") \
+   -e WEBHOOK_URL=http://host.docker.internal:8082/stripe/webhook \
+   -e WEBHOOK_SIGNING_SECRET \
+   -e CONNECT_WEBHOOK_URL=http://host.docker.internal:8082/stripe/connect-webhook \
+   -e CONNECT_WEBHOOK_SIGNING_SECRET \
+   fatsoma/localstripe:latest
 
 Docker image can be rebuilt using:
 

--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,7 @@ Only those events types are currently supported:
 - Invoice: ``invoice.created``, ``invoice.payment_succeeded`` and
   ``invoice.payment_failed``
 - PaymentIntent: ``payment_intent.created``, ``payment_intent.succeeded``, ``payment_intent.payment_failed`` and ``payment_intent.canceled``
+- PaymentMethod: ``payment_method.attached``, ``payment_method.detached``
 
 Flush stored data
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,7 @@ Only those events types are currently supported:
   ``customer.subscription.deleted``
 - Invoice: ``invoice.created``, ``invoice.payment_succeeded`` and
   ``invoice.payment_failed``
+- PaymentIntent: ``payment_intent.created``, ``payment_intent.succeeded``, ``payment_intent.payment_failed`` and ``payment_intent.canceled``
 
 Flush stored data
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -51,17 +51,17 @@ Then simply run the command ``localstripe``. The fake Stripe server is now
 listening on port 8420.
 
 Or launch a container using `the Docker image
-<https://hub.docker.com/r/adrienverge/localstripe/>`_:
+<https://hub.docker.com/r/fatsoma/localstripe/>`_:
 
 .. code:: shell
 
- docker run -p 8420:8420 adrienverge/localstripe:latest
+ docker run -p 8420:8420 fatsoma/localstripe:latest
 
 Docker image can be rebuilt using:
 
 .. code::
 
- docker build --no-cache -t adrienverge/localstripe .
+ docker build --no-cache -t fatsoma/localstripe .
 
 Examples
 --------

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+get_data() {
+  python -c "import json; import sys; print(json.load(sys.stdin)['data']['$1'])"
+}
+
+PORT=${PORT:-8420}
+if ! echo "$PORT" | grep -q '^[0-9]\+$' ; then
+  echo "Unexpected value for PORT: ${PORT}"
+  exit 1
+fi
+
+if [ -z "$WEBHOOK_URL" ] ||
+  [ -z "$CONNECT_WEBHOOK_URL" ] ||
+  [ -z "$WEBHOOK_SIGNING_SECRET" ] ||
+  [ -z "$CONNECT_WEBHOOK_SIGNING_SECRET" ]
+then
+  if [ -z "$ENVIRONMENT" ]; then
+    echo 'Missing ENVIRONMENT env variable'
+    exit 1
+  fi
+
+  vaultCmd=/usr/local/bin/vault
+
+  VAULT_SECRETS=
+  [ -n "$VAULT_ADDR" ] || export VAULT_ADDR=$VAULT_ADDRESS
+  if [ -n "$VAULT_ADDR" ]; then
+    token=$("$vaultCmd" login -token-only -method=aws role="$VAULT_ROLE") && \
+      VAULT_SECRETS=$(VAULT_TOKEN="$token" "$vaultCmd" kv get -format=json "secret/fatsoma/${ENVIRONMENT}/api/payment")
+    if [ -z "$WEBHOOK_URL" ]; then
+      WEBHOOK_URL=$(echo "$VAULT_SECRETS" | get_data 'stripe_webhook_url')
+    fi
+    if [ -z "$CONNECT_WEBHOOK_URL" ]; then
+      CONNECT_WEBHOOK_URL=$(echo "$VAULT_SECRETS" | get_data 'stripe_connect_webhook_url')
+    fi
+    if [ -z "$WEBHOOK_SIGNING_SECRET" ]; then
+      WEBHOOK_SIGNING_SECRET=$(echo "$VAULT_SECRETS" | get_data 'stripe_webhook_signing_secret')
+    fi
+    if [ -z "$CONNECT_WEBHOOK_SIGNING_SECRET" ]; then
+      CONNECT_WEBHOOK_SIGNING_SECRET=$(echo "$VAULT_SECRETS" | get_data 'stripe_connect_webhook_signing_secret')
+    fi
+  fi
+fi
+
+echo "Starting localstripe for setting webhooks"
+localstripe --from-scratch --port "$PORT" &
+
+echo "Setting webhook $WEBHOOK_URL"
+# shellcheck disable=SC2034
+for i in {1..100} ; do
+  sleep 0.2
+  ! curl -s -o/dev/null "localhost:${PORT}/_config/webhooks/webhook" \
+    -d "url=$WEBHOOK_URL" \
+    -d "secret=$WEBHOOK_SIGNING_SECRET" \
+    -d 'events[]=payment_intent.succeeded' \
+    -d 'events[]=payment_intent.payment_failed' \
+    -d 'events[]=payment_method.updated' \
+    -d 'events[]=payment_method.card_automatically_updated' \
+    -d 'events[]=payment_method.detached' \
+    || break
+done
+
+echo "Setting connect webhook $CONNECT_WEBHOOK_URL"
+curl -s -o/dev/null "localhost:${PORT}/_config/webhooks/connect-webhook" \
+  -d "url=$CONNECT_WEBHOOK_URL" \
+  -d "secret=$CONNECT_WEBHOOK_SIGNING_SECRET" \
+  -d 'events[]=payment_intent.succeeded' \
+  -d 'events[]=payment_intent.payment_failed'
+
+echo "Restarting localstripe"
+pgrep localstripe | xargs kill
+exec localstripe --port "$PORT"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -45,7 +45,7 @@ then
 fi
 
 echo "Starting localstripe"
-exec localstripe --port "$PORT" --config <<JSON
+exec localstripe --port "$PORT" --from-scratch --no-save --config <<JSON
 {
   "WebhookEndpoints": {
     "webhook": {

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 get_data() {
   python -c "import json; import sys; print(json.load(sys.stdin)['data']['$1'])"
 }

--- a/localstripe/errors.py
+++ b/localstripe/errors.py
@@ -36,4 +36,7 @@ class UserError(Exception):
             self.body['error']['message'] = message
 
     def to_response(self):
+        if self.__cause__ is not None:
+            self.body['error']['message'] += ': ' + repr(self.__cause__)
+
         return json_response(self.body, status=self.code)

--- a/localstripe/localstripe-v3.js
+++ b/localstripe/localstripe-v3.js
@@ -197,6 +197,7 @@ class Element {
     });
 
     this._domChildren.forEach((child) => domElement.appendChild(child));
+    (this.listeners['ready'] || []).forEach(handler => handler());
   }
 
   unmount() {
@@ -210,6 +211,34 @@ class Element {
     this.unmount();
     if (this._stripeElements._elements[this._type] === this) {
       this._stripeElements._elements[this._type] = null;
+    }
+  }
+
+  blur() {
+    Object.keys(this._inputs).forEach(field => {
+      this._inputs[field].blur();
+    });
+    (this.listeners['blur'] || []).forEach(handler => handler());
+  }
+
+  focus() {
+    var field = Object.keys(this._inputs)[0];
+    this._inputs[field].focus();
+    (this.listeners['focus'] || []).forEach(handler => handler());
+  }
+
+  clear() {
+    Object.keys(this._inputs).forEach(field => {
+      this._inputs[field].value = '';
+    });
+  }
+
+  update(options) {
+    if (!options) {
+      return;
+    }
+    if (options.value && options.value.postalCode && this._inputs.postal_code) {
+      this._inputs.postal_code.value = options.value.postalCode;
     }
   }
 

--- a/localstripe/localstripe-v3.js
+++ b/localstripe/localstripe-v3.js
@@ -217,6 +217,15 @@ class Element {
     this.listeners[event] = this.listeners[event] || [];
     this.listeners[event].push(handler);
   }
+
+  off(event, handler) {
+    if (handler) {
+      var i = this.listeners[event].indexOf(handler);
+      this.listeners[event].splice(i, 1);
+    } else {
+      delete this.listeners[event];
+    }
+  }
 }
 
 function Stripe(apiKey) {

--- a/localstripe/localstripe-v3.js
+++ b/localstripe/localstripe-v3.js
@@ -214,6 +214,12 @@ class Element {
                                        field === 'postal_code' ? 5 :
                                        field === 'cvc' ? 3 : 2);
       this._inputs[field].oninput = changed;
+      this._inputs[field].onblur = () => {
+        (this.listeners['blur'] || []).forEach(handler => handler());
+      };
+      this._inputs[field].onfocus = () => {
+        (this.listeners['focus'] || []).forEach(handler => handler());
+      }
       this._domChildren.push(this._inputs[field]);
     });
 

--- a/localstripe/localstripe-v3.js
+++ b/localstripe/localstripe-v3.js
@@ -198,7 +198,7 @@ class Element {
   }
 }
 
-Stripe = (apiKey) => {
+function Stripe(apiKey) {
   return {
     elements: () => {
       return {
@@ -418,7 +418,7 @@ Stripe = (apiKey) => {
 
     createPaymentMethod: async () => {},
   };
-};
+}
 
 console.log('localstripe: The Stripe object was just replaced in the page. ' +
             'Stripe elements created from now on will be fake ones, ' +

--- a/localstripe/localstripe-v3.js
+++ b/localstripe/localstripe-v3.js
@@ -18,7 +18,22 @@
 // First, get the domain from which this script is pulled:
 const LOCALSTRIPE_SOURCE = (function () {
   const scripts = document.getElementsByTagName('script');
-  const src = scripts[scripts.length - 1].src;
+  var src;
+
+  for (var i = 0; i < scripts.length; i++) {
+    src = scripts[i].src;
+    if (!src) {
+      continue;
+    }
+
+    var m = src.match(/((?:https?:)\/\/[^\/]*)\/js\.stripe\.com\/v3/);
+    if (m) {
+      return m[1];
+    }
+  }
+
+  // fallback on last script tag
+  src = scripts[scripts.length - 1].src;
   return src.match(/https?:\/\/[^\/]*/)[0];
 })();
 

--- a/localstripe/localstripe-v3.js
+++ b/localstripe/localstripe-v3.js
@@ -461,7 +461,7 @@ function Stripe(apiKey) {
             ...data.payment_method_data,
           }});
       },
-    confirmCardPayment: async (clientSecret, data) => {
+    confirmCardPayment: async (clientSecret, data, options) => {
       console.log('localstripe: Stripe().confirmCardPayment()');
       try {
         const success = await openModal(
@@ -585,6 +585,13 @@ function Stripe(apiKey) {
         }
       }
     },
+
+    confirmPaymentIntent: // deprecated
+      async function(clientSecret, data) {
+        return this.confirmCardPayment(clientSecret, data, {
+          handleActions: false,
+        });
+      },
 
     paymentRequest: function() {
       return {

--- a/localstripe/localstripe-v3.js
+++ b/localstripe/localstripe-v3.js
@@ -417,6 +417,32 @@ function Stripe(apiKey) {
     },
 
     createPaymentMethod: async () => {},
+
+    paymentRequest: function() {
+      return {
+        listeners: [],
+        abort: () => {},
+        canMakePayment: () => {
+          return new Promise(resolve => {
+            resolve(null);
+          });
+        },
+        show: () => {},
+        update: () => {},
+        on: (event, handler) => {
+          this.listeners[event] = this.listeners[event] || [];
+          this.listeners[event].push(handler);
+        },
+        off: (event, handler) => {
+          if (handler) {
+            var i = this.listeners[event].indexOf(handler);
+            this.listeners[event].splice(i, 1);
+          } else {
+            delete this.listeners[event];
+          }
+        }
+      };
+    },
   };
 }
 

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2121,8 +2121,10 @@ class PaymentIntent(StripeObject):
 
         if client_secret != obj.client_secret:
             raise UserError(401, 'Unauthorized')
-        if obj.status != 'requires_action':
-            raise UserError(400, 'Bad request: status must be requires_action')
+        if obj.status not in ('requires_action', 'requires_confirmation'):
+            raise UserError(400, 'Bad request: status must be ' +
+                            'requires_action or requires_confirmation',
+                            {'status': obj.status})
 
         obj.next_action = None
         if success:

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2272,6 +2272,7 @@ class PaymentMethod(StripeObject):
                             {'code': 'card_declined'})
 
         obj.customer = customer
+        schedule_webhook(Event('payment_method.attached', obj))
         return obj
 
     @classmethod
@@ -2286,6 +2287,7 @@ class PaymentMethod(StripeObject):
 
         obj = cls._api_retrieve(id)
         obj.customer = None
+        schedule_webhook(Event('payment_method.detached', obj))
         return obj
 
     @classmethod

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -39,6 +39,7 @@ _type = type
 class Store(dict):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.save_to_disk = True
 
     def try_load_from_disk(self):
         try:
@@ -51,6 +52,8 @@ class Store(dict):
             pass
 
     def dump_to_disk(self):
+        if not self.save_to_disk:
+            return
         with open('/tmp/localstripe.pickle', 'wb') as f:
             pickle.dump(self, f, protocol=pickle.HIGHEST_PROTOCOL)
 

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1982,6 +1982,7 @@ class PaymentIntent(StripeObject):
             if self.invoice:
                 invoice = Invoice._api_retrieve(self.invoice)
                 invoice._on_payment_success()
+            self._api_delete(self.id)
 
         def on_failure_now():
             schedule_webhook(Event('payment_intent.payment_failed', self))

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -977,6 +977,18 @@ class Customer(StripeObject):
         return super()._api_delete(id)
 
     @classmethod
+    def _api_list_all(cls, url, email=None, created=None, ending_before=None,
+                      limit=None, starting_after=None, **kwargs):
+        if kwargs:
+            raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
+
+        li = super()._api_list_all(url, limit, starting_after, **kwargs)
+
+        if email is not None:
+            li._list = [c for c in li._list if c.email == email]
+        return li
+
+    @classmethod
     def _api_retrieve_source(cls, id, source_id, **kwargs):
         if kwargs:
             raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -17,6 +17,7 @@
 import asyncio
 from datetime import datetime, timedelta
 import hashlib
+import json
 import pickle
 import random
 import re
@@ -52,6 +53,19 @@ class Store(dict):
     def dump_to_disk(self):
         with open('/tmp/localstripe.pickle', 'wb') as f:
             pickle.dump(self, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    def load_from_config(self, fp):
+        conf = json.load(fp)
+        if conf['WebhookEndpoints']:
+            self.load_config_webhooks(conf['WebhookEndpoints'])
+        self._restore_webhooks()
+
+    def load_config_webhooks(self, config):
+        for name in config:
+            obj = config[name]
+            WebhookEndpoint(url=obj['url'],
+                            _secret=obj['secret'],
+                            enabled_events=obj['events'])
 
     def _restore_webhooks(self):
         for key, obj in self.items():

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -200,7 +200,10 @@ async def save_store_middleware(request, handler):
             store.dump_to_disk()
 
 
+norm_path_middleware = web.normalize_path_middleware(append_slash=False,
+                                                     remove_slash=True)
 app = web.Application(middlewares=[error_middleware, auth_middleware,
+                                   norm_path_middleware,
                                    save_store_middleware])
 app.on_response_prepare.append(add_cors_headers)
 

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -306,12 +306,15 @@ async def config_webhook(request):
     url = data.get('url', None)
     secret = data.get('secret', None)
     events = data.get('events', None)
+    expand = data.pop('expand', None)
     if not url or not secret or not url.startswith('http'):
         raise UserError(400, 'Bad request')
     if events is not None and type(events) is not list:
         raise UserError(400, 'Bad request')
     register_webhook(id, url, secret, events)
-    return web.Response()
+    wh = WebhookEndpoint(id=id, url=url, enabled_events=events)
+    wh.secret = secret
+    return json_response(wh._export(expand=expand))
 
 
 async def flush_store(request):

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -169,6 +169,7 @@ async def auth_middleware(request, handler):
                 r'^/v1/tokens$',
                 r'^/v1/sources$',
                 r'^/v1/payment_intents/\w+/_authenticate\b',
+                r'^/v1/payment_methods$',
                 r'^/v1/setup_intents/\w+/confirm$',
                 r'^/v1/setup_intents/\w+/cancel$',
             )))

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -351,8 +351,10 @@ def start():
     parser.add_argument('--port', type=int, default=8420)
     parser.add_argument('--from-scratch', action='store_true')
     parser.add_argument('--config', action='store_true')
+    parser.add_argument('--no-save', default=False, action='store_true')
     args = parser.parse_args()
 
+    store.save_to_disk = not args.no_save
     if args.config:
         store.load_from_config(sys.stdin)
     if not args.from_scratch:

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -341,7 +341,7 @@ class AccessLogger(AbstractAccessLogger):
             return
 
         self.logger.info(f'{request.remote} '
-                         f'"{request.method} {request.path} '
+                         f'"{request.method} {request.path}" '
                          f'done in {time}s: {response.status}')
 
 

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -159,6 +159,9 @@ async def auth_middleware(request, handler):
     elif request.path.startswith('/_config/'):
         is_auth = True
 
+    elif request.path.startswith('/_status'):
+        is_auth = True
+
     else:
         # There are exceptions (for example POST /v1/tokens, POST /v1/sources)
         # where authentication can be done using the public key (passed as
@@ -322,8 +325,14 @@ async def flush_store(request):
     return web.Response()
 
 
+async def get_status(request):
+    return web.Response(text='{"status": "ok"}\n',
+                        content_type='application/json')
+
+
 app.router.add_post('/_config/webhooks/{id}', config_webhook)
 app.router.add_delete('/_config/data', flush_store)
+app.router.add_get('/_status', get_status)
 
 
 def start():

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -21,6 +21,7 @@ import logging
 import os.path
 import re
 import socket
+import sys
 
 from aiohttp import web
 from aiohttp.abc import AbstractAccessLogger
@@ -349,8 +350,11 @@ def start():
     parser = argparse.ArgumentParser()
     parser.add_argument('--port', type=int, default=8420)
     parser.add_argument('--from-scratch', action='store_true')
+    parser.add_argument('--config', action='store_true')
     args = parser.parse_args()
 
+    if args.config:
+        store.load_from_config(sys.stdin)
     if not args.from_scratch:
         store.try_load_from_disk()
 

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -24,8 +24,8 @@ import socket
 
 from aiohttp import web
 
-from .resources import BalanceTransaction, Charge, Coupon, Customer, Event, \
-    Invoice, InvoiceItem, PaymentIntent, PaymentMethod, Payout, Plan, \
+from .resources import Account, BalanceTransaction, Charge, Coupon, Customer, \
+    Event, Invoice, InvoiceItem, PaymentIntent, PaymentMethod, Payout, Plan, \
     Product, Refund, SetupIntent, Source, Subscription, SubscriptionItem, \
     TaxRate, Token, WebhookEndpoint, extra_apis, store
 from .errors import UserError
@@ -273,10 +273,10 @@ for method, url, func in extra_apis:
     app.router.add_route(method, url, api_extra(func, url))
 
 
-for cls in (BalanceTransaction, Charge, Coupon, Customer, Event, Invoice,
-            InvoiceItem, PaymentIntent, PaymentMethod, Payout, Plan, Product,
-            Refund, SetupIntent, Source, Subscription, SubscriptionItem,
-            TaxRate, Token, WebhookEndpoint):
+for cls in (Account, BalanceTransaction, Charge, Coupon, Customer, Event,
+            Invoice, InvoiceItem, PaymentIntent, PaymentMethod, Payout, Plan,
+            Product, Refund, SetupIntent, Source, Subscription,
+            SubscriptionItem, TaxRate, Token, WebhookEndpoint):
     for method, url, func in (
             ('POST', '/v1/' + cls.object + 's', api_create),
             ('GET', '/v1/' + cls.object + 's/{id}', api_retrieve),

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -316,8 +316,7 @@ async def config_webhook(request):
     if events is not None and type(events) is not list:
         raise UserError(400, 'Bad request')
     register_webhook(id, url, secret, events)
-    wh = WebhookEndpoint(id=id, url=url, enabled_events=events)
-    wh.secret = secret
+    wh = WebhookEndpoint(id=id, url=url, enabled_events=events, _secret=secret)
     return json_response(wh._export(expand=expand))
 
 

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -27,7 +27,7 @@ from aiohttp import web
 from .resources import BalanceTransaction, Charge, Coupon, Customer, Event, \
     Invoice, InvoiceItem, PaymentIntent, PaymentMethod, Payout, Plan, \
     Product, Refund, SetupIntent, Source, Subscription, SubscriptionItem, \
-    TaxRate, Token, extra_apis, store
+    TaxRate, Token, WebhookEndpoint, extra_apis, store
 from .errors import UserError
 from .webhooks import register_webhook
 
@@ -276,7 +276,7 @@ for method, url, func in extra_apis:
 for cls in (BalanceTransaction, Charge, Coupon, Customer, Event, Invoice,
             InvoiceItem, PaymentIntent, PaymentMethod, Payout, Plan, Product,
             Refund, SetupIntent, Source, Subscription, SubscriptionItem,
-            TaxRate, Token):
+            TaxRate, Token, WebhookEndpoint):
     for method, url, func in (
             ('POST', '/v1/' + cls.object + 's', api_create),
             ('GET', '/v1/' + cls.object + 's/{id}', api_retrieve),

--- a/localstripe/webhooks.py
+++ b/localstripe/webhooks.py
@@ -53,6 +53,7 @@ async def _send_webhook(event):
     await asyncio.sleep(1)
 
     logger = logging.getLogger('aiohttp.access')
+    logger.debug('sending webhook %s if registered' % event.type)
 
     for webhook in _webhooks.values():
         if webhook.events is not None and event.type not in webhook.events:

--- a/localstripe/webhooks.py
+++ b/localstripe/webhooks.py
@@ -37,6 +37,14 @@ def register_webhook(id, url, secret, events):
     _webhooks[id] = Webhook(url, secret, events)
 
 
+def unregister_webhook(id):
+    del _webhooks[id]
+
+
+def list_webhooks():
+    return _webhooks
+
+
 async def _send_webhook(event):
     payload = json.dumps(event._export(), indent=2, sort_keys=True)
     payload = payload.encode('utf-8')

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     name='localstripe',
     version=__version__,
     author=__author__,
-    url='https://github.com/adrienverge/localstripe',
+    url='https://github.com/Fatsoma/localstripe',
     description=('A fake but stateful Stripe server that you can run locally, '
                  'for testing purposes.'),
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174342202

This work should be cherry-picked out into multiple PRs to request
changes upstream. For brevity, all changes are being made for supporting
Fatsoma here.

* [x] Add Webhook Endpoints resource at `/v1/webhook_endpoints`. Keep
existing `/_config/webhooks` for registering webhooks with specified
secrets.
* [x] Fix `LOCALSTRIPE_SOURCE` in js to work when not the last script
element in the page.
* [x] Add Account resource at `/v1/accounts` and standard account at
`/v1/account`
* [x] Add middleware to strip trailing slash from URLs
* [x] Add details to `400: Bad Request` errors to indicate which params
are missing or invalid.
* [ ] Add Stripe Connect resources
* [ ] Add Payment Intent resources
* [ ] Anything else?